### PR TITLE
Order item ship / cancel

### DIFF
--- a/app/controllers/order_items_controller.rb
+++ b/app/controllers/order_items_controller.rb
@@ -1,5 +1,5 @@
 class OrderItemsController < ApplicationController
-  before_action :set_order_item, only: [:more, :less, :destroy]
+  before_action :set_order_item, only: [:more, :less, :update, :destroy]
 
   def more # increases the item quantity in the cart by 1
     @order_item.more!
@@ -15,6 +15,16 @@ class OrderItemsController < ApplicationController
     flash[:errors] = @order_item.errors if @order_item.errors
 
     redirect_to cart_path
+  end
+
+  def update
+    if params[:ship] == "true"
+      @order_item.mark_shipped
+    elsif params[:cancel] == "true"
+      @order_item.mark_canceled
+    end
+
+    redirect_to :back
   end
 
   def destroy

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -9,7 +9,7 @@ class OrdersController < ApplicationController
 
   def checkout
     @order.prepare_checkout!
-    flash[:errors] = @order.errors if @order.errors
+    flash[:errors] = @order.errors unless @order.errors.empty?
   end
 
   def add_to_cart # OPTIMIZE: consider moving this elsewhere, i.e. ProductsController or OrderItemsController.

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -48,7 +48,7 @@ class OrdersController < ApplicationController
   end
 
   def show
-    @items = @order.order_items.select { |item| item.seller.id == @seller.id }
+    @order_items = @order.order_items.select { |item| item.seller.id == @seller.id }
   end
 
   private

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -34,13 +34,13 @@ class Order < ActiveRecord::Base
 
 
   def prepare_checkout!
-    items_adjusted = false
-    order_items.each do |item|
-      item.adjust_if_product_stock_changed!
-      items_adjusted = true unless item.errors.empty?
+    quantity_ordered_adjusted = false
+    order_items.each do |order_item|
+      order_item.adjust_if_product_stock_changed!
+      quantity_ordered_adjusted = true unless order_item.errors.empty?
     end
 
-    if items_adjusted # OPTIMIZE: this error message in prepare_checkout!
+    if quantity_ordered_adjusted # OPTIMIZE: this error message in prepare_checkout!
       errors[:product_stock] = "Quantity ordered was adjusted because not enough of this product was stuck."
     end
   end
@@ -48,9 +48,13 @@ class Order < ActiveRecord::Base
   def checkout!(checkout_params)
     checkout_params[:status] = "paid"
     if update(checkout_params)
-      order_items.each do |item|
-        item.remove_product_stock!
+      order_items.each do |order_item|
+        order_item.remove_product_stock!
+        order_item.status = "paid" # TODO: add testing for this
       end
+      return true
+    else
+      return false
     end
   end
 

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -50,7 +50,7 @@ class Order < ActiveRecord::Base
     if update(checkout_params)
       order_items.each do |order_item|
         order_item.remove_product_stock!
-        order_item.status = "paid" # TODO: add testing for this
+        order_item.update(status: "paid") # TODO: add testing for this
       end
       return true
     else

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -14,8 +14,6 @@ class OrderItem < ActiveRecord::Base
   validate :order_item_is_unique?
 
 
-  # mutative methods
-
   def more!
     if product_has_stock? && product.stock > quantity_ordered
       increment!(:quantity_ordered, 1)
@@ -43,8 +41,15 @@ class OrderItem < ActiveRecord::Base
     product.remove_stock!(quantity_ordered)
   end
 
+  def mark_shipped # TODO: add tests
+    self.update(status: "shipped")
+  end
 
-  # non-mutative
+  def mark_canceled # TODO: add tests
+    self.update(status: "canceled")
+
+    product.add_stock!(quantity_ordered)
+  end
 
   def total_item_price
     quantity_ordered * product.price
@@ -61,7 +66,7 @@ class OrderItem < ActiveRecord::Base
   private
 
     # validation helper method
-    def order_item_is_unique? # TODO: anw, fix failing spec after merge. Also, write specs for this!
+    def order_item_is_unique? # TODO: write specs for this!
       if OrderItem.where(product_id: product_id, order_id: order_id).count > 0
         errors.add(:product_not_unique, "That product is already in your cart.")
       end

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -11,7 +11,7 @@ class OrderItem < ActiveRecord::Base
   validates :product_id, presence: true, numericality: { only_integer: true, greater_than: 0 }
   validates :order_id, presence: true, numericality: { only_integer: true, greater_than: 0 }
   validates :quantity_ordered, presence: true, numericality: { only_integer: true, greater_than: 0 }
-  validate :order_item_is_unique?
+  validate :order_item_is_unique?, on: [:create]
 
 
   def more!

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -11,6 +11,8 @@ class OrderItem < ActiveRecord::Base
   validates :product_id, presence: true, numericality: { only_integer: true, greater_than: 0 }
   validates :order_id, presence: true, numericality: { only_integer: true, greater_than: 0 }
   validates :quantity_ordered, presence: true, numericality: { only_integer: true, greater_than: 0 }
+  validates :status, presence: true, inclusion: { in: %w(pending paid complete canceled),
+    message: "%{value} is not a valid status" } # TODO: add tests
   validate :order_item_is_unique?, on: [:create]
 
 

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -13,15 +13,11 @@ class Product < ActiveRecord::Base
   # Scopes ---------------------------------------------------------------------
   scope :has_stock, -> { where(retired: false).where("stock > 0") }
 
-  # non-mutative class method
-
   def self.top_products
     sorted_products = self.has_stock.sort_by { |product| product.average_rating }.reverse!
     top_products = sorted_products.first(12)
   end
 
-
-  # mutative methods
 
   def retire!
     update(retired: retired ? false : true)
@@ -47,9 +43,6 @@ class Product < ActiveRecord::Base
       errors[:remove_stock] << "You can't remove more stock than is present."
     end
   end
-
-
-  # non-mutative methods
 
   def average_rating
     total_num_reviews = self.reviews.count

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -18,11 +18,14 @@
       <td><%= order_item.quantity_ordered %></td>
       <td><%= order_item.product.name %></td>
       <td><%= display_dollars(order_item.total_item_price) %></td>
-      <td><%= @order.status %></td>
+      <td><%= order_item.status %></td>
       <td>
-        <!-- # FIXME: these buttons don't do anything see bug https://trello.com/c/iPWevY4r -->
-        <%= link_to "Ship", root_path, method: :get, class: "btn btn-default" %>
-        <%= link_to "Cancel", root_path, method: :get, class: "btn btn-warning" %>
+      <% if order_item.status == "paid" %>
+        <%= button_to "Ship", order_item_path(order_item), method: :patch, params: { ship: true }, class: "btn btn-default" %>
+      <% end %>
+      <% unless order_item.status == "canceled" %>
+        <%= button_to "Cancel", order_item_path(order_item), method: :patch, params: { cancel: true }, class: "btn btn-warning" %>
+      <% end %>
       </td>
     </tr>
   <% end %>

--- a/app/views/orders/show.html.erb
+++ b/app/views/orders/show.html.erb
@@ -13,11 +13,11 @@
     <th>Status</th>
     <th>Options</th>
   </tr>
-  <% @items.each do |item| %>
+  <% @order_items.each do |order_item| %>
     <tr>
-      <td><%= item.quantity_ordered %></td>
-      <td><%= item.product.name %></td>
-      <td><%= display_dollars(item.total_item_price) %></td>
+      <td><%= order_item.quantity_ordered %></td>
+      <td><%= order_item.product.name %></td>
+      <td><%= display_dollars(order_item.total_item_price) %></td>
       <td><%= @order.status %></td>
       <td>
         <!-- # FIXME: these buttons don't do anything see bug https://trello.com/c/iPWevY4r -->

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,4 +38,6 @@ Rails.application.routes.draw do
 
   # removing an item from the cart
   delete "/cart/item/:id", to: "order_items#destroy", as: "kill_item"
+
+  resources :order_items, only: [:update]
 end

--- a/db/migrate/20150724121726_add_status_to_order_items.rb
+++ b/db/migrate/20150724121726_add_status_to_order_items.rb
@@ -1,0 +1,5 @@
+class AddStatusToOrderItems < ActiveRecord::Migration
+  def change
+    add_column :order_items, :status, :string, default: "pending", null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150723230739) do
+ActiveRecord::Schema.define(version: 20150724121726) do
 
   create_table "categories", force: :cascade do |t|
     t.string   "name",       null: false
@@ -28,11 +28,12 @@ ActiveRecord::Schema.define(version: 20150723230739) do
   add_index "categories_products", ["product_id"], name: "index_categories_products_on_product_id"
 
   create_table "order_items", force: :cascade do |t|
-    t.integer  "product_id",       null: false
-    t.integer  "order_id",         null: false
-    t.integer  "quantity_ordered", null: false
-    t.datetime "created_at",       null: false
-    t.datetime "updated_at",       null: false
+    t.integer  "product_id",                           null: false
+    t.integer  "order_id",                             null: false
+    t.integer  "quantity_ordered",                     null: false
+    t.datetime "created_at",                           null: false
+    t.datetime "updated_at",                           null: false
+    t.string   "status",           default: "pending", null: false
   end
 
   create_table "orders", force: :cascade do |t|

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -12,14 +12,11 @@ sellers = [
 ]
 
 sellers.each do |username, email, password|
-  seller = Seller.new(username: username, email: email)
-  seller.password = password
-  seller.password_confirmation = password
-  seller.save
+  seller = Seller.create(username: username, email: email, password: password, password_confirmation: password)
 end
 
 def rando_seller_id
-  return (1..10).to_a.sample
+  rand(1..Seller.count)
 end
 
 def rando_price
@@ -309,7 +306,6 @@ def review_text(rating, product)
   return fives.sample if rating == 5
 end
 
-
 products.each do |product|
   product = Product.create(product)
 
@@ -342,7 +338,7 @@ buyer_names = [
   "Ada Lovelace", "Betty McAwesomePants", "Tallis GenericLastName", "Tux"
 ]
 
-product_limit = Product.all.count
+product_limit = Product.count
 
 20.times do
   current_name = buyer_names.sample
@@ -352,16 +348,13 @@ product_limit = Product.all.count
     buyer_card_expiration: Date.parse("June 5 2086"))
 
   10.times do
-    OrderItem.create(product_id: (1..product_limit).to_a.sample,
-      order_id: order.id, quantity_ordered: 2)
+    OrderItem.create(product_id: rand(1..product_limit),
+      order_id: order.id, quantity_ordered: 2, status: "paid")
   end
 end
 
-all_categories = Category.all
-all_products = Product.all
-
-all_products.each do |product|
-  product.categories << all_categories.sample(rand(0..4))
+Product.all.each do |product|
+  product.categories << Category.all.sample(rand(0..4))
 end
 
 reviews = [

--- a/spec/controllers/orders_controller_spec.rb
+++ b/spec/controllers/orders_controller_spec.rb
@@ -410,11 +410,11 @@ RSpec.describe OrdersController, type: :controller do
       expect(assigns(:order)).to eq(@order)
     end
 
-    it "assigns @items" do
+    it "assigns @order_items" do
       get :show, seller_id: @seller.id, id: @order.id
 
-      expect(assigns(:items)).to include(@item1)
-      expect(assigns(:items)).to include(@item2)
+      expect(assigns(:order_items)).to include(@item1)
+      expect(assigns(:order_items)).to include(@item2)
     end
   end
 end

--- a/spec/models/order_item_spec.rb
+++ b/spec/models/order_item_spec.rb
@@ -2,32 +2,30 @@ require 'rails_helper'
 
 RSpec.describe OrderItem, type: :model do
   before :each do
-    @seller = Seller.new(username: "a", email: "bob@bob.bob")
-    @seller.password = @seller.password_confirmation = "password"
-    @seller.save
+    @seller = Seller.create(username: "a", email: "bob@bob.bob", password: "password", password_confirmation: "password")
     @product = Product.create(name: "a", price: 1, seller_id: 1, stock: 5)
     @order = Order.create
-    @item = OrderItem.create(product_id: @product.id, order_id: @order.id, quantity_ordered: 1)
+    @order_item = OrderItem.create(product_id: @product.id, order_id: @order.id, quantity_ordered: 1)
   end
 
   describe "database relationships" do
     it "belongs to an order" do
-      expect(@item.order).to eq(@order)
+      expect(@order_item.order).to eq(@order)
     end
 
     it "belongs to a product" do
-      expect(@item.product).to eq(@product)
+      expect(@order_item.product).to eq(@product)
     end
 
     it "has a seller through its product" do
-      expect(@item.seller.id).to eq(@seller.id)
+      expect(@order_item.seller.id).to eq(@seller.id)
     end
   end
 
   describe "model validations" do
     context "product_id" do
       it "requires a product_id" do
-        valid_item = OrderItem.create(product_id: @product.id)
+        valid_item = @order_item
         expect(valid_item.errors.keys).to_not include(:product_id)
 
         invalid_item = OrderItem.create
@@ -36,7 +34,7 @@ RSpec.describe OrderItem, type: :model do
       end
 
       it "must have a numeric value" do
-        valid_item = OrderItem.create(product_id: 1)
+        valid_item = @order_item
         expect(valid_item.errors.keys).to_not include(:product_id)
 
         invalid_item = OrderItem.create(product_id: "four thousand")
@@ -45,7 +43,7 @@ RSpec.describe OrderItem, type: :model do
       end
 
       it "must be an integer value" do
-        valid_item = OrderItem.create(product_id: @product.id)
+        valid_item = @order_item
         expect(valid_item.errors.keys).to_not include(:product_id)
 
         invalid_item = OrderItem.create(product_id: 4.1)
@@ -54,7 +52,7 @@ RSpec.describe OrderItem, type: :model do
       end
 
       it "must be greater than zero" do
-        valid_item = OrderItem.create(product_id: 1)
+        valid_item = @order_item
         expect(valid_item.errors.keys).to_not include(:product_id)
 
         invalid_item = OrderItem.create(product_id: -4)


### PR DESCRIPTION
Allows seller to mark an order item as shipped or canceled.

Also marks an order_item as paid when an order is marked as paid.

Minor additional code changes, including changing the seed file (so that the paid orders also had paid order items!)
